### PR TITLE
DOCKER: fix Dockerfile and django_init script to work under Windows

### DIFF
--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -6,11 +6,11 @@ RUN apt-get update \
     && apt-get clean
 RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
 RUN apt-get install -y nodejs
-COPY docker/django/django_init /usr/local/bin
+COPY docker/django/django_init.sh /usr/local/bin
 WORKDIR /opt/happyschool
 COPY Pipfile .
 COPY package.json .
 RUN npm install
 RUN python3 -m pip install pipenv
 RUN pipenv install --dev
-CMD ["/usr/local/bin/django_init"]
+CMD ["/usr/local/bin/django_init.sh"]

--- a/docker/django/django_init.sh
+++ b/docker/django/django_init.sh
@@ -13,9 +13,10 @@ done
 
 if [ ! -d "/opt/happyschool/static/bundles/" ]; then
     ./node_modules/.bin/webpack --config webpack.dev.js
-    pipenv run ./manage.py migrate
-    pipenv run ./manage.py creategroups;
-    pipenv run ./manage.py shell -c 'from django.contrib.auth import get_user_model; get_user_model().objects.create_superuser("admin", "admin@localhost", "admin")'
+    pipenv run python3 manage.py migrate
+    pipenv run python3 manage.py creategroups;
+    pipenv run python3 manage.py shell -c 'from django.contrib.auth import get_user_model; get_user_model().objects.create_superuser("admin", "admin@localhost", "admin")'
 fi
 
-exec pipenv run ./manage.py runserver 0.0.0.0:8000
+pipenv run python3 manage.py runserver 0.0.0.0:8000 
+


### PR DESCRIPTION
Hello @Supermanu ,

J'ai commencé à écrire de la documentation mais mon Ubuntu a craché. 
Quand j'étais sous Ubuntu je n'avais pas de soucis avec Docker.

J'ai voulu alors installer le projet avec Windows mais j'ai du faire quelques petits changements : 
- Le script django_init doit avoir une extension sinon il ne trouve pas le script
- Il faut que les commandes avec manage.py soient appelées avec "python3" sinon ça ne fonctionne pas, il me dit qu'il ne trouve pas python 

L'image semble fonctionner au top maintenant mais je ne sais pas ce que ça donne sur Linux.
Est-ce que cela te convient ?

Bon week-end.

